### PR TITLE
Feature/better error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # OS et IDE files
 .DS_Store
 .idea/
-*.sublime-projet
+.vscode/
+*.sublime-project
 *.sublime-workspace
 node_modules/
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/gulp-config",
-  "version": "1.1.4",
+  "version": "1.1.5-beta.0",
   "description": "Gulp configuration",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gulp-stylelint": "^8.0.0",
     "gulp-uglify": "^3.0.1",
     "lodash": "^4.17.11",
+    "node-notifier": "^5.3.0",
     "node-sass-magic-importer": "^5.3.0",
     "pretty-error": "^2.1.1",
     "stylelint": "^9.10.0"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gulp-uglify": "^3.0.1",
     "lodash": "^4.17.11",
     "node-sass-magic-importer": "^5.3.0",
+    "pretty-error": "^2.1.1",
     "stylelint": "^9.10.0"
   },
   "directories": {

--- a/src/tasks/scripts.js
+++ b/src/tasks/scripts.js
@@ -6,7 +6,7 @@ import sourcemaps from 'gulp-sourcemaps';
 import uglify from 'gulp-uglify';
 import notify from 'gulp-notify';
 import cache from 'gulp-cached';
-import prettyError from '../utils/pretty-error';
+import errorHandler from '../utils/error-handler';
 
 /**
  * Create the `scripts-build` Gulp task
@@ -46,10 +46,7 @@ export const createScriptsBuilder = (options) => {
       source(resolve(src, glob))
         .pipe(cache(name))
         .pipe(sourcemaps.init())
-        .pipe(uglify(uglifyOptions).on('error', function err(error) {
-          prettyError.render(error, true);
-          return this.emit('end');
-        }))
+        .pipe(uglify(uglifyOptions).on('error', errorHandler))
         .pipe(sourcemaps.write('maps'))
         .pipe(dest(dist))
         .pipe(notify({

--- a/src/tasks/scripts.js
+++ b/src/tasks/scripts.js
@@ -6,6 +6,7 @@ import sourcemaps from 'gulp-sourcemaps';
 import uglify from 'gulp-uglify';
 import notify from 'gulp-notify';
 import cache from 'gulp-cached';
+import prettyError from '../utils/pretty-error';
 
 /**
  * Create the `scripts-build` Gulp task
@@ -29,10 +30,6 @@ export const createScriptsBuilder = (options) => {
         drop_console: true,
       },
     },
-    uglifyErrorHandler: ({ message }) => {
-      console.log(message);
-      notify.onError({ message });
-    },
   };
 
   /** @type {Object} Merge the defaults and custom options */
@@ -41,7 +38,6 @@ export const createScriptsBuilder = (options) => {
     glob,
     dist,
     uglifyOptions,
-    uglifyErrorHandler,
   } = merge({}, defaults, options);
 
   return [
@@ -50,7 +46,10 @@ export const createScriptsBuilder = (options) => {
       source(resolve(src, glob))
         .pipe(cache(name))
         .pipe(sourcemaps.init())
-        .pipe(uglify(uglifyOptions).on('error', uglifyErrorHandler))
+        .pipe(uglify(uglifyOptions).on('error', function err(error) {
+          prettyError.render(error, true);
+          return this.emit('end');
+        }))
         .pipe(sourcemaps.write('maps'))
         .pipe(dest(dist))
         .pipe(notify({
@@ -65,7 +64,6 @@ export const createScriptsBuilder = (options) => {
       glob,
       dist,
       uglifyOptions,
-      uglifyErrorHandler,
     },
   ];
 };

--- a/src/tasks/styles.js
+++ b/src/tasks/styles.js
@@ -14,7 +14,7 @@ import sassInheritance from 'gulp-sass-multi-inheritance';
 import cache from 'gulp-cached';
 import filter from 'gulp-filter';
 import magicImporter from 'node-sass-magic-importer';
-import prettyImporter from '../utils/pretty-error';
+import errorHandler from '../utils/error-handler';
 
 /**
  * Create the styles compilation task
@@ -72,10 +72,7 @@ export const createStylesBuilder = (options) => {
           !/\/_/.test(file.path) || !/^_/.test(file.relative)
         )))
         .pipe(sourcemaps.init())
-        .pipe(sass.sync(gulpSassOptions).on('error', function err(error) {
-          prettyImporter.render(error, true);
-          return this.emit('end');
-        }))
+        .pipe(sass.sync(gulpSassOptions).on('error', errorHandler))
         .pipe(postcss(postCssPlugins))
         .pipe(cleanCss(cleanCssOptions))
         .pipe(sourcemaps.write('map'))

--- a/src/tasks/styles.js
+++ b/src/tasks/styles.js
@@ -14,6 +14,7 @@ import sassInheritance from 'gulp-sass-multi-inheritance';
 import cache from 'gulp-cached';
 import filter from 'gulp-filter';
 import magicImporter from 'node-sass-magic-importer';
+import prettyImporter from '../utils/pretty-error';
 
 /**
  * Create the styles compilation task
@@ -71,7 +72,10 @@ export const createStylesBuilder = (options) => {
           !/\/_/.test(file.path) || !/^_/.test(file.relative)
         )))
         .pipe(sourcemaps.init())
-        .pipe(sass.sync(gulpSassOptions).on('error', sass.logError))
+        .pipe(sass.sync(gulpSassOptions).on('error', function err(error) {
+          prettyImporter.render(error, true);
+          return this.emit('end');
+        }))
         .pipe(postcss(postCssPlugins))
         .pipe(cleanCss(cleanCssOptions))
         .pipe(sourcemaps.write('map'))

--- a/src/utils/error-handler.js
+++ b/src/utils/error-handler.js
@@ -1,0 +1,21 @@
+import PrettyError from 'pretty-error';
+import notifier from 'node-notifier';
+
+const prettyError = new PrettyError();
+
+/**
+ * Custom error handler
+ *
+ * @param  {Error} error The error to display
+ * @return {void}
+ */
+export default function errorHandler(error) {
+  notifier.notify({
+    title: 'Error',
+    message: error.message,
+  });
+
+  prettyError.render(error, true);
+
+  return this.emit('end');
+};

--- a/src/utils/pretty-error.js
+++ b/src/utils/pretty-error.js
@@ -1,4 +1,0 @@
-import PrettyError from 'pretty-error';
-
-// Export a new instance of Pretty Error
-export default new PrettyError();

--- a/src/utils/pretty-error.js
+++ b/src/utils/pretty-error.js
@@ -1,0 +1,4 @@
+import PrettyError from 'pretty-error';
+
+// Export a new instance of Pretty Error
+export default new PrettyError();

--- a/tests/src/scripts/error.js
+++ b/tests/src/scripts/error.js
@@ -1,0 +1,6 @@
+(function(window) {
+  'use strict';
+
+  const error = 'foo';
+  window.error = error;
+})(window);

--- a/tests/src/styles/error.scss
+++ b/tests/src/styles/error.scss
@@ -1,0 +1,4 @@
+.foo {
+  display: block;
+  color: $blue;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4999,7 +4999,7 @@ node-gyp@^3.8.0:
     tar "^2.0.0"
     which "1"
 
-node-notifier@^5.2.1:
+node-notifier@^5.2.1, node-notifier@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.3.0.tgz#c77a4a7b84038733d5fb351aafd8a268bfe19a01"
   integrity sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,6 +1265,11 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1931,12 +1936,27 @@ css-node-extract@^2.1.3:
     change-case "^3.0.1"
     postcss "^6.0.14"
 
+css-select@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
 css-selector-extract@^3.3.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/css-selector-extract/-/css-selector-extract-3.3.6.tgz#5cc670cfeae743015e80faf2d722d7818657e3e5"
   integrity sha512-bBI8ZJKKyR9iHvxXb4t3E6WTMkis94eINopVg7y2FmmMjLXUVduD7mPEcADi4i9FX4wOypFMFpySX+0keuefxg==
   dependencies:
     postcss "^6.0.14"
+
+css-what@2.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
+  integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
 
 css@2.X, css@^2.2.1:
   version "2.2.4"
@@ -2147,6 +2167,13 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-converter@~0.2:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
+  integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
+  dependencies:
+    utila "~0.4"
+
 dom-serializer@0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -2165,11 +2192,33 @@ domelementtype@~1.1.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
   integrity sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=
 
+domhandler@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.1.0.tgz#d2646f5e57f6c3bab11cf6cb05d3c0acf7412594"
+  integrity sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=
+  dependencies:
+    domelementtype "1"
+
 domhandler@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
+    domelementtype "1"
+
+domutils@1.1:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
+  integrity sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+  dependencies:
+    dom-serializer "0"
     domelementtype "1"
 
 domutils@^1.5.1:
@@ -3597,6 +3646,16 @@ htmlparser2@^3.10.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.0.6"
+
+htmlparser2@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.3.0.tgz#cc70d05a59f6542e43f0e685c982e14c924a9efe"
+  integrity sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=
+  dependencies:
+    domelementtype "1"
+    domhandler "2.1"
+    domutils "1.1"
+    readable-stream "1.0"
 
 http-errors@1.6.3, http-errors@~1.6.2:
   version "1.6.3"
@@ -5098,6 +5157,13 @@ npm-run-path@^2.0.0:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+  dependencies:
+    boolbase "~1.0.0"
+
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
@@ -5762,6 +5828,14 @@ prettier@^1.15.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
   integrity sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==
 
+pretty-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
+  integrity sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=
+  dependencies:
+    renderkid "^2.0.1"
+    utila "~0.4"
+
 pretty-hrtime@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -5936,16 +6010,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@2 || 3", readable-stream@^3.0.6:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.1.tgz#ed6bbc6c5ba58b090039ff18ce670515795aeb06"
-  integrity sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-"readable-stream@>=1.0.33-1 <1.1.0-0":
+readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0":
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
@@ -5954,6 +6019,15 @@ read-pkg@^3.0.0:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+"readable-stream@2 || 3", readable-stream@^3.0.6:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.1.tgz#ed6bbc6c5ba58b090039ff18ce670515795aeb06"
+  integrity sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@~2.3.6:
   version "2.3.6"
@@ -6148,6 +6222,17 @@ remove-trailing-separator@^1.0.1, remove-trailing-separator@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
+renderkid@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.2.tgz#12d310f255360c07ad8fde253f6c9e9de372d2aa"
+  integrity sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==
+  dependencies:
+    css-select "^1.1.0"
+    dom-converter "~0.2"
+    htmlparser2 "~3.3.0"
+    strip-ansi "^3.0.0"
+    utila "^0.4.0"
 
 repeat-element@^1.1.2:
   version "1.1.3"
@@ -7560,6 +7645,11 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+utila@^0.4.0, utila@~0.4:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
+  integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
 
 utils-merge@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Set up a better error handling mechanism : 

- errors are now nicely logged in the console
- errors are now displaid in notifications
- errors do not break watch/server tasks anymore

This feature is testable on the package beta version:

```bash
npm install --save-dev @studiometa/gulp-config@beta
# or
yarn add --dev @studiometa/gulp-config@beta
```