### PR TITLE
Feature/diff only

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
     "lodash": "^4.17.11",
     "node-notifier": "^5.3.0",
     "node-sass-magic-importer": "^5.3.0",
+    "plugin-error": "^1.0.1",
     "pretty-error": "^2.1.1",
-    "stylelint": "^9.10.0"
+    "stylelint": "^9.10.0",
+    "through2": "^3.0.0"
   },
   "directories": {
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/gulp-config",
-  "version": "1.1.5-beta.7",
+  "version": "1.2.0-beta.0",
   "description": "Gulp configuration",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "browser-sync": "^2.26.3",
     "command-line-args": "^5.0.2",
     "eslint": "^5.12.0",
+    "fancy-log": "^1.3.3",
     "gulp": "^4.0.0",
     "gulp-cached": "^1.1.1",
     "gulp-clean-css": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "gulp",
     "compile": "babel --plugins @babel/plugin-transform-runtime --out-dir dist/ src/",
-    "prepare": "npm run compile"
+    "prepare": "npm run compile",
+    "lint": "eslint src/",
+    "fix": "eslint --fix src/"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/runtime": "^7.3.4",
     "autoprefixer": "^9.4.5",
     "browser-sync": "^2.26.3",
+    "command-line-args": "^5.0.2",
     "eslint": "^5.12.0",
     "gulp": "^4.0.0",
     "gulp-cached": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/gulp-config",
-  "version": "1.1.5-beta.4",
+  "version": "1.1.5-beta.5",
   "description": "Gulp configuration",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "gulp-cli": "^2.0.1",
     "gulp-eslint": "^5.0.0",
     "gulp-filter": "^5.1.0",
-    "gulp-if": "^2.0.2",
     "gulp-notify": "^3.2.0",
     "gulp-postcss": "^8.0.0",
     "gulp-sass": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/gulp-config",
-  "version": "1.1.5-beta.5",
+  "version": "1.1.5-beta.6",
   "description": "Gulp configuration",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/gulp-config",
-  "version": "1.1.5-beta.6",
+  "version": "1.1.5-beta.7",
   "description": "Gulp configuration",
   "main": "dist/index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ All the [defaults Gulp CLI flags](https://github.com/gulpjs/gulp-cli#flags) can 
   <tbody>
     <tr>
       <td>--diff-only</td>
-      <td></td>
+      <td>-d</td>
       <td>Execute the given task only on files listed in your `git diff`.</td>
     </tr>
   </tbody>

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,8 @@
 A small helper to simplify the usage of Gulp to compile, lint, fix, compress and live-reload SCSS and JS files.^
 
 - [Usage](#usage)
-- [Options](#options)
+  + [CLI options](#cli-options)
+- [Configuration](#configuration)
   + [Styles](#styles)
     * [`src`](#stylessrc-string)
     * [`glob`](#stylesglob-string)
@@ -64,7 +65,28 @@ The `gulp` default tasks will execute the build and lint tasks before the server
 
 The server tasks watch automatically for changes in the styles and scripts files to re-trigger the build and lint tasks.
 
-## Options
+### CLI options
+
+All the [defaults Gulp CLI flags](https://github.com/gulpjs/gulp-cli#flags) can be used when running a task, with the following custom ones:
+
+<table>
+  <thead>
+    <tr>
+      <th width="25%">Flag</th>
+      <th width="15%">Short Flag</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>--diff-only</td>
+      <td></td>
+      <td>Execute the given task only on files listed in your `git diff`.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Configuration
 
 The main options object can contain 3 different keys : [`styles`](#styles), [`scripts`](#scripts) and [`server`](#server). If one of them is omitted, the corresponding tasks won't be created. Find below the description and default values for each configuration object.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
 import { series } from 'gulp';
 import isObject from 'lodash/isObject';
-import isArray from 'lodash/isArray';
-import merge from 'lodash/merge';
 import { createServer } from './tasks/server';
 import {
   createStylesBuilder,

--- a/src/plugins/gulp-diff.js
+++ b/src/plugins/gulp-diff.js
@@ -1,0 +1,51 @@
+import through from 'through2';
+import PluginError from 'plugin-error';
+import { execSync } from 'child_process';
+
+/**
+ * Check if a file has changed or not
+ *
+ * @param  {Vinyl}   file         A vinyl file
+ * @param  {Array}   filesChanged A list of changed files
+ * @return {Boolean}              Whether the file has changed or not
+ */
+function fileHasChanged(file, filesChanged) {
+  const currentFile = file.path.substr(process.cwd().length + 1);
+  return filesChanged.indexOf(currentFile) > -1;
+}
+
+/**
+ * Filter file by their diff status
+ * @return {Vinyl}
+ */
+export default function diff() {
+  const cmd = 'git diff --name-only';
+  const filesChanged = execSync(cmd, { encoding: 'utf8' })
+    .split('\n')
+    .filter(file => file.length > 0);
+
+  return through.obj(
+    /* eslint-disable-next-line */
+    function(file, enc, cb) {
+      if (file.isNull()) {
+        cb(null, file);
+        return;
+      }
+
+      if (file.isStream()) {
+        const error = new PluginError('gulp-diff', 'Streaming not supported');
+        cb(error);
+        return;
+      }
+
+      try {
+        if (fileHasChanged(file, filesChanged)) {
+          this.push(file);
+        }
+      } catch (err) {
+        this.emit('error', new PluginError('gulp-diff', err));
+      }
+      cb();
+    }
+  );
+}

--- a/src/plugins/gulp-diff.js
+++ b/src/plugins/gulp-diff.js
@@ -30,13 +30,21 @@ export default function diff(isDiffOnly = false) {
     .join('\n    ');
 
   if (isDiffOnly) {
-    log.warn(`
+    if (changedFiles.length > 0) {
+      log(`
 
     The '${colors.green('--diff-only')}' option is enabled, the task will only
     process the following matching modified files:
 
     ${colors.red(formattedChangedFiles)}
-    `);
+      `);
+    } else {
+      log(`
+
+    The '${colors.green('--diff-only')}' option is enabled, but you do not have
+    any modified files in your repository, nothing will happen.
+      `);
+    }
   }
 
   return through.obj(

--- a/src/tasks/scripts.js
+++ b/src/tasks/scripts.js
@@ -6,7 +6,10 @@ import sourcemaps from 'gulp-sourcemaps';
 import uglify from 'gulp-uglify';
 import notify from 'gulp-notify';
 import cache from 'gulp-cached';
+import gif from 'gulp-if';
 import errorHandler from '../utils/error-handler';
+import args from '../utils/arguments';
+import diff from '../plugins/gulp-diff';
 
 /**
  * Create the `scripts-build` Gulp task
@@ -44,6 +47,7 @@ export const createScriptsBuilder = (options) => {
     name,
     () => (
       source(resolve(src, glob))
+        .pipe(gif(args.diffOnly, diff()))
         .pipe(cache(name))
         .pipe(sourcemaps.init())
         .pipe(uglify(uglifyOptions).on('error', errorHandler))
@@ -97,6 +101,7 @@ export const createScriptsLinter = (options) => {
     name,
     () => (
       source(resolve(src, glob))
+        .pipe(gif(args.diffOnly, diff()))
         .pipe(cache(name))
         .pipe(eslint(ESLintOptions))
         .pipe(eslint.format())
@@ -140,6 +145,7 @@ export const createScriptsFormatter = (options) => {
     name,
     () => (
       source(resolve(src, glob))
+        .pipe(gif(args.diffOnly, diff()))
         .pipe(cache(name))
         .pipe(eslint(ESLintOptions))
         .pipe(dest(src))

--- a/src/tasks/scripts.js
+++ b/src/tasks/scripts.js
@@ -6,10 +6,9 @@ import sourcemaps from 'gulp-sourcemaps';
 import uglify from 'gulp-uglify';
 import notify from 'gulp-notify';
 import cache from 'gulp-cached';
-import gif from 'gulp-if';
 import errorHandler from '../utils/error-handler';
-import args from '../utils/arguments';
 import diff from '../plugins/gulp-diff';
+import args from '../utils/arguments';
 
 /**
  * Create the `scripts-build` Gulp task
@@ -47,7 +46,7 @@ export const createScriptsBuilder = (options) => {
     name,
     () => (
       source(resolve(src, glob))
-        .pipe(gif(args.diffOnly, diff()))
+        .pipe(diff(args.diffOnly))
         .pipe(cache(name))
         .pipe(sourcemaps.init())
         .pipe(uglify(uglifyOptions).on('error', errorHandler))
@@ -101,7 +100,7 @@ export const createScriptsLinter = (options) => {
     name,
     () => (
       source(resolve(src, glob))
-        .pipe(gif(args.diffOnly, diff()))
+        .pipe(diff(args.diffOnly))
         .pipe(cache(name))
         .pipe(eslint(ESLintOptions))
         .pipe(eslint.format())
@@ -145,7 +144,7 @@ export const createScriptsFormatter = (options) => {
     name,
     () => (
       source(resolve(src, glob))
-        .pipe(gif(args.diffOnly, diff()))
+        .pipe(diff(args.diffOnly))
         .pipe(cache(name))
         .pipe(eslint(ESLintOptions))
         .pipe(dest(src))

--- a/src/tasks/styles.js
+++ b/src/tasks/styles.js
@@ -14,7 +14,10 @@ import sassInheritance from 'gulp-sass-multi-inheritance';
 import cache from 'gulp-cached';
 import filter from 'gulp-filter';
 import magicImporter from 'node-sass-magic-importer';
+import gif from 'gulp-if';
 import errorHandler from '../utils/error-handler';
+import args from '../utils/arguments';
+import diff from '../plugins/gulp-diff';
 
 /**
  * Create the styles compilation task
@@ -66,6 +69,7 @@ export const createStylesBuilder = (options) => {
     name,
     () => (
       source(resolve(src, glob))
+        .pipe(gif(args.diffOnly, diff()))
         .pipe(cache(name))
         .pipe(sassInheritance({ dir: src }))
         .pipe(filter(file => (
@@ -137,6 +141,7 @@ export const createStylesLinter = (options) => {
     name,
     () => (
       source(resolve(src, glob))
+        .pipe(gif(args.diffOnly, diff()))
         .pipe(cache(name))
         .pipe(styleLint(styleLintOptions))
     ),
@@ -188,6 +193,7 @@ export const createStylesFormatter = (options) => {
     name,
     () => (
       source(resolve(src, glob))
+        .pipe(gif(args.diffOnly, diff()))
         .pipe(cache(name))
         .pipe(styleLint(styleLintOptions))
         .pipe(dest(src))

--- a/src/tasks/styles.js
+++ b/src/tasks/styles.js
@@ -14,7 +14,6 @@ import sassInheritance from 'gulp-sass-multi-inheritance';
 import cache from 'gulp-cached';
 import filter from 'gulp-filter';
 import magicImporter from 'node-sass-magic-importer';
-import gif from 'gulp-if';
 import errorHandler from '../utils/error-handler';
 import args from '../utils/arguments';
 import diff from '../plugins/gulp-diff';
@@ -69,7 +68,7 @@ export const createStylesBuilder = (options) => {
     name,
     () => (
       source(resolve(src, glob))
-        .pipe(gif(args.diffOnly, diff()))
+        .pipe(diff(args.diffOnly))
         .pipe(cache(name))
         .pipe(sassInheritance({ dir: src }))
         .pipe(filter(file => (
@@ -141,7 +140,7 @@ export const createStylesLinter = (options) => {
     name,
     () => (
       source(resolve(src, glob))
-        .pipe(gif(args.diffOnly, diff()))
+        .pipe(diff(args.diffOnly))
         .pipe(cache(name))
         .pipe(styleLint(styleLintOptions))
     ),
@@ -193,7 +192,7 @@ export const createStylesFormatter = (options) => {
     name,
     () => (
       source(resolve(src, glob))
-        .pipe(gif(args.diffOnly, diff()))
+        .pipe(diff(args.diffOnly))
         .pipe(cache(name))
         .pipe(styleLint(styleLintOptions))
         .pipe(dest(src))

--- a/src/utils/arguments.js
+++ b/src/utils/arguments.js
@@ -1,0 +1,16 @@
+import commandLineArgs from 'command-line-args';
+
+/** @type {Array} All available arguments definitions */
+const optionsDefintions = [
+  {
+    name: 'diff-only',
+    type: Boolean,
+  },
+];
+
+// Export the parsed command line options
+export default commandLineArgs(optionsDefintions, {
+  partial: true,
+  stopAtFirstUnknown: false,
+  camelCase: true,
+});

--- a/src/utils/arguments.js
+++ b/src/utils/arguments.js
@@ -4,6 +4,7 @@ import commandLineArgs from 'command-line-args';
 const optionsDefintions = [
   {
     name: 'diff-only',
+    alias: 'd',
     type: Boolean,
   },
 ];

--- a/src/utils/error-handler.js
+++ b/src/utils/error-handler.js
@@ -30,11 +30,9 @@ Error: ${message}
  * @param  {Error} error The error to format
  * @return {Error}       The formatted error
  */
-const formatError = (error) => {
-  return 'cause' in error
-    ? formatUglifyError(error)
-    : error;
-};
+const formatError = error => ('cause' in error
+  ? formatUglifyError(error)
+  : error);
 
 
 /**
@@ -52,4 +50,4 @@ export default function errorHandler(error) {
   });
 
   return this.emit('end');
-};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2816,7 +2816,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fancy-log@^1.3.2:
+fancy-log@^1.3.2, fancy-log@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.3.tgz#dbc19154f558690150a23953a0adbd035be45fc7"
   integrity sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7314,7 +7314,7 @@ through2@2.X, through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through2@3.0.0:
+through2@3.0.0, through2@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.0.tgz#468b461df9cd9fcc170f22ebf6852e467e578ff2"
   integrity sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,6 +944,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv-tools@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/argv-tools/-/argv-tools-0.1.1.tgz#588283f3393ada47141440b12981cd41bf6b7032"
+  integrity sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==
+  dependencies:
+    array-back "^2.0.0"
+    find-replace "^2.0.1"
+
 arr-diff@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-1.1.0.tgz#687c32758163588fef7de7b36fabe495eb1a399a"
@@ -992,6 +1000,13 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-back@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-2.0.0.tgz#6877471d51ecc9c9bfa6136fb6c7d5fe69748022"
+  integrity sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==
+  dependencies:
+    typical "^2.6.1"
 
 array-differ@^1.0.0:
   version "1.0.0"
@@ -1773,6 +1788,17 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
+
+command-line-args@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.0.2.tgz#c4e56b016636af1323cf485aa25c3cb203dfbbe4"
+  integrity sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==
+  dependencies:
+    argv-tools "^0.1.1"
+    array-back "^2.0.0"
+    find-replace "^2.0.1"
+    lodash.camelcase "^4.3.0"
+    typical "^2.6.1"
 
 commander@^2.2.0, commander@^2.8.1:
   version "2.19.0"
@@ -2885,6 +2911,14 @@ finalhandler@1.1.0:
     parseurl "~1.3.2"
     statuses "~1.3.1"
     unpipe "~1.0.0"
+
+find-replace@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-2.0.1.tgz#6d9683a7ca20f8f9aabeabad07e4e2580f528550"
+  integrity sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==
+  dependencies:
+    array-back "^2.0.0"
+    test-value "^3.0.0"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -4511,6 +4545,11 @@ lodash.assign@^4.0.3, lodash.assign@^4.0.6, lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
   integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
 lodash.clonedeep@^4.3.2:
   version "4.5.0"
@@ -7230,6 +7269,14 @@ ternary-stream@^2.0.1:
     merge-stream "^1.0.0"
     through2 "^2.0.1"
 
+test-value@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/test-value/-/test-value-3.0.0.tgz#9168c062fab11a86b8d444dd968bb4b73851ce92"
+  integrity sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==
+  dependencies:
+    array-back "^2.0.0"
+    typical "^2.6.1"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -7446,6 +7493,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typical@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
+  integrity sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=
 
 ua-parser-js@0.7.17:
   version "0.7.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,7 +2281,7 @@ duplexer@^0.1.1, duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
-duplexify@^3.2.0, duplexify@^3.5.0, duplexify@^3.6.0:
+duplexify@^3.2.0, duplexify@^3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.6.1.tgz#b1a7a29c4abfd639585efaecce80d666b1e34125"
   integrity sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==
@@ -3025,11 +3025,6 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-fork-stream@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/fork-stream/-/fork-stream-0.0.4.tgz#db849fce77f6708a5f8f386ae533a0907b54ae70"
-  integrity sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=
-
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -3415,22 +3410,6 @@ gulp-filter@^5.1.0:
     multimatch "^2.0.0"
     plugin-error "^0.1.2"
     streamfilter "^1.0.5"
-
-gulp-if@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/gulp-if/-/gulp-if-2.0.2.tgz#a497b7e7573005041caa2bc8b7dda3c80444d629"
-  integrity sha1-pJe351cwBQQcqivIt92jyARE1ik=
-  dependencies:
-    gulp-match "^1.0.3"
-    ternary-stream "^2.0.1"
-    through2 "^2.0.1"
-
-gulp-match@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/gulp-match/-/gulp-match-1.0.3.tgz#91c7c0d7f29becd6606d57d80a7f8776a87aba8e"
-  integrity sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=
-  dependencies:
-    minimatch "^3.0.3"
 
 gulp-notify@^3.2.0:
   version "3.2.0"
@@ -7258,16 +7237,6 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
-
-ternary-stream@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ternary-stream/-/ternary-stream-2.0.1.tgz#064e489b4b5bf60ba6a6b7bc7f2f5c274ecf8269"
-  integrity sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=
-  dependencies:
-    duplexify "^3.5.0"
-    fork-stream "^0.0.4"
-    merge-stream "^1.0.0"
-    through2 "^2.0.1"
 
 test-value@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Fixes #10.

You can now run `gulp styles-build --diff-only` to only process the files which have been modified according to the current `git diff`.

This feature can already be tested in the latest beta version 1.1.5-beta.5.
