### PR TITLE
Feature/improve logged info

### DIFF
--- a/src/plugins/gulp-log.js
+++ b/src/plugins/gulp-log.js
@@ -1,0 +1,21 @@
+import log from 'fancy-log';
+import through from 'through2';
+import colors from 'gulp-cli/lib/shared/ansi';
+
+/**
+ * Log the given logger
+ *
+ * @param  {Function|String} logger A function that returns a string to log
+ * @return {Vinyl}
+ */
+export default function(logger) {
+  return through.obj((file, enc, cb) => {
+    if (typeof logger === 'function') {
+      log(logger(file, colors));
+    } else if (typeof logger === 'string') {
+      log(logger);
+    }
+
+    cb();
+  });
+}

--- a/src/tasks/scripts.js
+++ b/src/tasks/scripts.js
@@ -14,6 +14,7 @@ import errorHandler from '../utils/error-handler';
 import cache from '../plugins/gulp-cache';
 import diff from '../plugins/gulp-diff';
 import noop from '../plugins/gulp-noop';
+import log from '../plugins/gulp-log';
 import args from '../utils/arguments';
 import nameFunction from '../utils/name-function';
 
@@ -138,10 +139,20 @@ export const createScriptsBuilder = options => {
         .pipe(
           gif(
             !args.quiet,
-            notify({
-              title: `gulp ${name}`,
-              message: ({ relative }) =>
-                `The file ${relative} has been updated.`,
+            notify(
+              JSON.parse(
+                JSON.stringify({
+                  title: `gulp ${name}`,
+                  message: 'The file <%= file.relative %> has been updated.',
+                })
+              )
+            ),
+            log((file, colors) => {
+              const coloredName = colors.blue(`gulp ${name}`);
+              const msg = `The file ${colors.green(
+                file.relative
+              )} has been updated.`;
+              return `[${coloredName}] ${msg}`;
             })
           )
         )

--- a/src/tasks/scripts.js
+++ b/src/tasks/scripts.js
@@ -1,4 +1,5 @@
 import { src as source, dest } from 'gulp';
+import { extname } from 'path';
 import merge from 'lodash/merge';
 import eslint from 'gulp-eslint';
 import sourcemaps from 'gulp-sourcemaps';
@@ -6,6 +7,7 @@ import gulpUglify from 'gulp-uglify';
 import notify from 'gulp-notify';
 import babel from 'gulp-babel';
 import gif from 'gulp-if';
+import filter from 'gulp-filter';
 import webpack from 'webpack';
 import webpackStream from 'webpack-stream';
 import errorHandler from '../utils/error-handler';
@@ -132,6 +134,7 @@ export const createScriptsBuilder = options => {
         .pipe(dest(dist))
         .pipe(hooks.afterDest())
         .pipe(hooks.beforeNotify())
+        .pipe(filter(file => extname(file.path) !== '.map'))
         .pipe(
           gif(
             !args.quiet,

--- a/src/tasks/styles.js
+++ b/src/tasks/styles.js
@@ -17,6 +17,7 @@ import errorHandler from '../utils/error-handler';
 import args from '../utils/arguments';
 import cache from '../plugins/gulp-cache';
 import diff from '../plugins/gulp-diff';
+import log from '../plugins/gulp-log';
 import sassInheritance from '../plugins/gulp-sass-inheritance';
 import nameFunction from '../utils/name-function';
 
@@ -85,10 +86,20 @@ export const createStylesBuilder = options => {
         .pipe(
           gif(
             !args.quiet,
-            notify({
-              title: `gulp ${name}`,
-              message: ({ relative }) =>
-                `The file ${relative} has been updated.`,
+            notify(
+              JSON.parse(
+                JSON.stringify({
+                  title: `gulp ${name}`,
+                  message: 'The file <%= file.relative %> has been updated.',
+                })
+              )
+            ),
+            log((file, colors) => {
+              const coloredName = colors.blue(`gulp ${name}`);
+              const msg = `The file ${colors.green(
+                file.relative
+              )} has been updated.`;
+              return `[${coloredName}] ${msg}`;
             })
           )
         )

--- a/src/tasks/styles.js
+++ b/src/tasks/styles.js
@@ -1,5 +1,5 @@
 import { src as source, dest } from 'gulp';
-import { resolve, basename } from 'path';
+import { resolve, basename, extname } from 'path';
 import isArray from 'lodash/isArray';
 import sass from 'gulp-dart-sass';
 import cleanCss from 'gulp-clean-css';
@@ -81,6 +81,7 @@ export const createStylesBuilder = options => {
         .pipe(sourcemaps.write('maps'))
         .pipe(dest(file => file.base.replace(srcAbsolute, distAbsolute)))
         .pipe(browserSync.stream())
+        .pipe(filter(file => extname(file.path) !== '.map'))
         .pipe(
           gif(
             !args.quiet,


### PR DESCRIPTION
This features includes the following changes:

- Display some information about the generated files in the console when notification are disabled (with `--quiet` or `-q`)
- Fix a bug where `gulp-notify` would sometimes throw an error of invalid syntax
